### PR TITLE
Remove proxy_mgr2 from lua config.

### DIFF
--- a/deployment/conf/.templates/lua.templ
+++ b/deployment/conf/.templates/lua.templ
@@ -4,14 +4,6 @@ lua_shared_dict token_cache 2m;
 lua_shared_dict proxy_mgr 100k;
 lua_shared_dict lock_map 2m;
 
-{{ if eq .Env.nginx_site_cfg "prod-narrative" }}
-lua_shared_dict session_map_legacy 1m;
-lua_shared_dict docker_map_legacy 2m;
-lua_shared_dict token_cache_legacy 2m;
-lua_shared_dict proxy_mgr_legacy 100k;
-lua_shared_dict lock_map_legacy 2m;
-{{ end }}
-
 # load lua files
 lua_package_path "/kb/deployment/services/narrative/docker/?;/kb/deployment/services/narrative/docker/?.lua;;";
 
@@ -27,26 +19,10 @@ init_by_lua '
 		proxy_mgr = ngx.shared.proxy_mgr,
 		provision_count = {{ default .Env.narr_provision_count "20" }}
 	}
-{{ if eq .Env.nginx_site_cfg "prod-narrative"}}
-	proxymgr2 = require("proxy_mgr2")
-	proxymgr2:initialize{
-		lock_name = "lock_map_legacy",
-		session_map = ngx.shared.session_map_legacy,
-		docker_map = ngx.shared.docker_map_legacy,
-		token_cache = ngx.shared.token_cache_legacy,
-		proxy_mgr = ngx.shared.proxy_mgr_legacy,
-		provision_count = 10,
-		image = "kbase/narrative:legacy"
-	}
-{{ end }}
 ';
 
 # start worker processes
 init_worker_by_lua '
 	proxymgr:check_marker()
 	proxymgr:check_provisioner(0)
-{{ if eq .Env.nginx_site_cfg "prod-narrative"}}
-	proxymgr2:check_marker()
-	proxymgr2:check_provisioner(0)
-{{ end }}
 ';


### PR DESCRIPTION
We are no longer supporting the legacy containers in production.  This PR removes them because it was causing hangups in the lua marker thread.